### PR TITLE
add legacy badge to tools that are no longer actively maintained

### DIFF
--- a/interface/buildUI.js
+++ b/interface/buildUI.js
@@ -2225,9 +2225,22 @@ function populateViz(tool) {
 	const titleBlock = document.createElement('div');
 	titleBlock.className = 'viz-title';
 
+	const titleRow = document.createElement('div');
+	titleRow.className = 'viz-title-row';
+
 	const h3 = document.createElement('h3');
 	h3.textContent = tool["Tool ID::Tool name"];
-	titleBlock.appendChild(h3);
+	titleRow.appendChild(h3);
+
+	const activeMaintenance = (tool['1. Software::1. Active maintenance'] || '').trim().toLowerCase();
+	if (activeMaintenance === 'no' || activeMaintenance === 'legacy') {
+		const legacyBadge = document.createElement('span');
+		legacyBadge.className = 'legacy-badge';
+		legacyBadge.innerHTML = '<i class="fa-solid fa-box-archive"></i> Legacy';
+		titleRow.appendChild(legacyBadge);
+	}
+
+	titleBlock.appendChild(titleRow);
 
 	if (tool["Tool ID::Website"]) {
 		const websiteLink = document.createElement('a');
@@ -2405,6 +2418,14 @@ function buildTools() {
 		// Title
 		const h3 = document.createElement('h3');
 		h3.textContent = tool["Tool ID::Tool name"];
+		const cardMaintenance = (tool['1. Software::1. Active maintenance'] || '').trim().toLowerCase();
+		if (cardMaintenance === 'no' || cardMaintenance === 'legacy') {
+			const legacyMarker = document.createElement('span');
+			legacyMarker.className = 'card-legacy-marker';
+			legacyMarker.textContent = 'L';
+			legacyMarker.title = 'Legacy tool';
+			h3.appendChild(legacyMarker);
+		}
 		// const link = document.createElement('a');
 		// link.href = tool["Tool ID::Website"];
 		// link.target = "_blank";

--- a/interface/styles.css
+++ b/interface/styles.css
@@ -488,6 +488,23 @@ h1.app-subtitle {
     float: left;
 }
 
+.card-legacy-marker {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.3em;
+    height: 1.3em;
+    margin-left: 0.4em;
+    border-radius: 50%;
+    background: #fff0da;
+    border: 1px solid #f4c17d;
+    color: #9a4d00;
+    font-size: 0.68em;
+    font-weight: 700;
+    line-height: 1;
+    vertical-align: middle;
+}
+
 .bottom {
   overflow: hidden;
   display: flex;
@@ -532,10 +549,32 @@ h1.app-subtitle {
   gap: 4px;
 }
 
+.viz-title-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
 .viz-title h3 {
   margin: 0;
   font-size: 1.1rem;
   color: var(--pumpkin);
+}
+
+.legacy-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #fff0da;
+  border: 1px solid #f4c17d;
+  color: #9a4d00;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 
 .viz-link {


### PR DESCRIPTION
Added clearer legacy indicators for tools that are no longer actively maintained.

Tools with `Active maintenance: No` now show a Legacy badge in the bottom-left detail panel and a compact circular L badge in the top-left tool list, making their status visible both before and after opening the tool details.